### PR TITLE
Potential fix for code scanning alert no. 3: Code injection

### DIFF
--- a/vulnerable.js
+++ b/vulnerable.js
@@ -13,11 +13,20 @@ app.use(bodyParser.json());
  */
 app.post('/execute', (req, res) => {
     let userInput = req.body.code;
-    try {
-        let result = vm.runInNewContext(userInput); // ⚠️ UNSAFE: Executes user-supplied JavaScript code
-        res.json({ result });
-    } catch (error) {
-        res.status(500).json({ error: 'Execution failed' });
+    const allowedOperations = {
+        'operation1': () => { return 'Result of operation 1'; },
+        'operation2': () => { return 'Result of operation 2'; },
+        // Add more allowed operations as needed
+    };
+    if (allowedOperations.hasOwnProperty(userInput)) {
+        try {
+            let result = allowedOperations[userInput]();
+            res.json({ result });
+        } catch (error) {
+            res.status(500).json({ error: 'Execution failed' });
+        }
+    } else {
+        res.status(400).json({ error: 'Invalid operation' });
     }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/nanzggits/lasttest/security/code-scanning/3](https://github.com/nanzggits/lasttest/security/code-scanning/3)

To fix this issue, we need to avoid executing user-supplied code directly. Instead, we should use a safer approach to handle the user input. One way to achieve this is by using a predefined set of allowed operations or commands that the user can request, and then safely executing those commands without using `vm.runInNewContext`.

- Replace the direct execution of user-supplied code with a controlled set of allowed operations.
- Validate the user input to ensure it matches one of the allowed operations.
- Execute the corresponding operation safely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
